### PR TITLE
FEAT(#435): PAGINATE DONATION LIST

### DIFF
--- a/main/templates/donation/list.html
+++ b/main/templates/donation/list.html
@@ -68,6 +68,24 @@ displayed in the preview text (e.g. "donación")
 <div id="data" data-json='{{ objects_json|safe }}'></div>
 <div id="object-name" data-name='{{ object_name }}'></div>
 
+<div class="pagination">
+  <span class="step-links">
+      {% if objects.has_previous %}
+          <a href="?page=1">&laquo; Primera</a>
+          <a href="?page={{ page_obj.previous_page_number }}">Anterior</a>
+      {% endif %}
+
+      <span class="current">
+          Página {{ objects.number }} de {{ objects.paginator.num_pages }}.
+      </span>
+
+      {% if objects.has_next %}
+          <a href="?page={{ objects.next_page_number }}">Siguiente</a>
+          <a href="?page={{ objects.paginator.num_pages }}">Última &raquo;</a>
+      {% endif %}
+  </span>
+</div>
+
 {% endblock %}
 
 


### PR DESCRIPTION
Pagination for Donations done with default pagination of 12 objects. Pagination for frontend template has also been added. To test the functionality well, I recommend creating a donation (in any way) and then in the SQL Workbench copy the rows and paste, until you get 13 rows, just enough to test the pagination.