### PR TITLE
FIX(#462): STRAIGHTEN PAYMENT'S LATERAL PANEL

### DIFF
--- a/main/templates/layouts/master_clean_sidebar.html
+++ b/main/templates/layouts/master_clean_sidebar.html
@@ -28,7 +28,7 @@ BLOCKS IN THIS LAYOUT
 
 <div class="row complete">
 
-    <div class="pt-4 px-0 col-md-5 h-100 d-flex align-items-center">
+    <div class="pt-4 px-0 col-md-5 col-12 h-100 d-flex align-items-center">
       <div class="w-100  fs-4 text-center d-flex flex-column ">
         
         {%block leftSide%}{%endblock%}

--- a/main/templates/payment/payment_form.html
+++ b/main/templates/payment/payment_form.html
@@ -4,14 +4,13 @@
 <link rel="stylesheet" type="text/css" href="{% static 'styles/payment_form.css' %}">
 {% endblock %}
 {% block leftSide %}
-
 {% include 'components/title2.html' with title=title %}
 
 <form method="post" action="">
   {% csrf_token %}
-    <div class="row my-4 mx-5">
+    <div class="row my-4 mx-5 justify-content-center">
       
-      <div class="my-4 mx-5 d-flex flex-column text-start">
+      <div class="my-2 mx-5 d-flex flex-column text-start">
         <div class="mt-3">
           {% include "components/inputs.html" with id=form.concept.id_for_label label_text=form.concept.label_tag input=form.concept %} 
           {{ form.concept.errors }}


### PR DESCRIPTION
It wasn't alligned with the column.

Check:
- [x] The payment lateral panel's title is centered in all responsive sizes
- [x] The payment lateral panel's form is centered in all responsive sizes

Doubts:
- [x] Should the section have colours like a user?