### PR TITLE
FEAT(#463): ADD LIST TABLES HEADERS

### DIFF
--- a/main/templates/components/card-list.html
+++ b/main/templates/components/card-list.html
@@ -1,31 +1,23 @@
 {% load static %}
 <div class=" container-fluid card-list mw-100 px-2 card-list rounded py-1" tabindex="1">
   <span class="object-id d-none">{{ object.id }}</span>
-   
       
     <div class="row">
-      <div class="col-md-6 col-lg-4 col-sm-6 ">
-        <strong><h5>{{object.surname}}, {{object.name}}</h5></strong>
+      <div class="col-lg-4 col-6">
+        <strong><h5 title="{{object.surname}}, {{object.name}}">{{object.surname}}, {{object.name}}</h5></strong>
       
       </div>
-      <div class="col-md-2 col-lg-2 col-sm-2">
+      <div class="col-lg-3 col-6">
         <span>{{object.city}}</span>
 
       </div>  
-      <div class="col-md-3 col-lg-2  col-sm-1">
+      <div class="col-lg-2 col-6">
         <span>{{object.telephone}}</span>
 
       </div> 
-      <div class="col-md-2 col-sm-1 col-lg-2 col-sm-1 col-email ">
+      <div class="col-lg-3 col-6">
         <span>{{object.email}}</span>
       </div> 
-
-        
-        
-  
-    
-    
-
 
   </div>
 

--- a/main/templates/donation/list.html
+++ b/main/templates/donation/list.html
@@ -18,27 +18,38 @@ displayed in the preview text (e.g. "donación")
 {% endblock %}
 
 {% block objectFor %}
-{% for object in objects %}
 
+<!-- TABLE HEADER -->
+<div id="id-tableHeader" class="container-fluid">
+  <div class="row">
+    <div class="col-lg-5 col-6"><strong>Título</strong></div>
+    <div class="col-lg-3 col-6"><strong>Fecha de presentación</strong></div>
+    <div class="col-lg-2 col-6"><strong>Cantidad</strong></div>
+    <div class="col-lg-2 col-6"><strong>E-mail</strong></div>
+  </div>
+  <hr class="my-1">
+</div>
+
+{% for object in objects %}
 
 <div class="container-fluid mw-100 px-2 card-list rounded py-1" id="donation-{{ object.id }}" tabindex="1">
   <span class="object-id d-none">{{ object.id }}</span>
        
   <div class="row">
-    <div class="col-md-4 col-lg-3 col-sm-5 ">
-      <strong><h5>{{object.title}}</h5></strong>
+    <div class="col-lg-5 col-6">
+      <strong><h5 title="{{object.title}}">{{object.title}}</h5></strong>
 
     </div>
-    <div class="col-md-2 col-lg-2 col-sm-1">
+    <div class="col-lg-3 col-6">
       <span>{{object.created_date}}</span>
 
     </div>  
-    <div class="col-md-3 col-lg-2  col-sm-1">
+    <div class="col-lg-2 col-6">
       <span>{{object.amount}} €</span>
 
     </div> 
-    <div class="col-md-2 col-sm-1 col-lg-2 col-email ">
-      <span>{{object.donor_email}}</span>
+    <div class="col-lg-2 col-6">
+      <span class="text-break text-wrap">{{object.donor_email}}</span>
 
       </div> 
 
@@ -110,7 +121,7 @@ displayed in the preview text (e.g. "donación")
         <div class="row ">
           <div class="col-12 px-4">
             
-            <h2>${objectData.title}</h2>
+            <h2 title="${objectData.title}">${objectData.title}</h2>
             <h5>{{object_name}}</h5>
             <p>${objectData.description}</p>
             <p><strong>Cantidad:  </strong>${objectData.amount} €</p>

--- a/main/templates/home/list.html
+++ b/main/templates/home/list.html
@@ -18,29 +18,41 @@ displayed in the preview text (e.g. "donación")
 {% endblock %}
 
 {% block objectFor %}
-<form method="GET">
+<form method="GET" class="mb-4">
   {% csrf_token %}
   {{form}}
   <input type="submit" value="Filtrar">
 </form>
+
+<!-- TABLE HEADER -->
+<div id="id-tableHeader" class="container-fluid">
+  <div class="row">
+    <div class="col-lg-5 col-6"><strong>Nombre</strong></div>
+    <div class="col-lg-2 col-6"><strong>Provincia</strong></div>
+    <div class="col-lg-3 col-6"><strong>Cantidad</strong></div>
+    <div class="col-lg-2 col-6"><strong>Frecuencia de pago</strong></div>
+  </div>
+  <hr class="my-1">
+</div>
+
 {% for object in objects %}
 <div class="container-fluid mw-100 px-2 card-list rounded py-1" tabindex="1">
     <span class="object-id d-none">{{ object.id }}</span>
    
     <div class="row">
-      <div class="col-md-5 col-lg-4 col-sm-6 ">
-        <strong><h5>{{object.name}}</h5></strong>
+      <div class="col-lg-5 col-6">
+        <strong><h5 title="{{object.name}}">{{object.name}}</h5></strong>
       </div>
 
-      <div class="col-md-2 col-lg-2 col-sm-1">
+      <div class="col-lg-2 col-6">
         <span>{{object.province}}</span>
       </div>
 
-      <div class="col-md-3 col-lg-2  col-sm-1">
+      <div class="col-lg-3 col-6">
         <span>{{object.amount}} €</span>
       </div>
 
-      <div class="col-md-2 col-sm-1 col-lg-2 col-email ">
+      <div class="col-lg-2 col-6">
         <span>{{object.frequency}}</span>
       </div>
 
@@ -107,7 +119,7 @@ displayed in the preview text (e.g. "donación")
           preview.innerHTML = `
         <div class="row ">
           <div class="col-12 px-4 ">
-            <h2>${objectData.name}</h2>
+            <h2 title="${objectData.name}">${objectData.name}</h2>
             <h5>{{object_name}}</h5>
             <p>${objectData.province}</p>
             <p><strong>Cantidad:  </strong>${objectData.amount} €</p>

--- a/main/templates/project/list.html
+++ b/main/templates/project/list.html
@@ -18,12 +18,23 @@ displayed in the preview text (e.g. "donación")
 {% endblock %}
 
 {% block objectFor %}
-<form method="GET">
+<form method="GET" class="mb-4">
   {% csrf_token %}
   {{form}}
   <input type="submit" value="Filtrar">
   <button type="reset" class="btn btn-secondary">Borrar filtros</button>
 </form>
+
+<!-- TABLE HEADER -->
+<div id="id-tableHeader" class="container-fluid">
+  <div class="row">
+    <div class="col-6"><strong>T&iacute;tulo</strong></div>
+    <div class="col-3"><strong>Pa&iacute;s</strong></div>
+    <div class="col-3"><strong>Fecha de inicio</strong></div>
+  </div>
+  <hr class="my-1">
+</div>
+
 {% for object in objects %}
 
 <div class="container-fluid mw-100 px-2 card-list rounded py-1" tabindex="1">
@@ -31,7 +42,7 @@ displayed in the preview text (e.g. "donación")
     <div class="row">
 
       <div class="col-6">
-        <strong><h5>{{object.title}}</h5></strong>
+        <strong><h5 title="{{object.title}}">{{object.title}}</h5></strong>
       </div>
 
       <div class="col-3">
@@ -100,7 +111,7 @@ displayed in the preview text (e.g. "donación")
         <div class="row ">
           <div class="col-12  px-4">
             
-            <h2>${objectData.title ? objectData.title : 'No especificado' }</h2>
+            <h2 title="${objectData.title ? objectData.title : 'No especificado' }">${objectData.title ? objectData.title : 'No especificado' }</h2>
             <h5>{{object_name}}</h5>
             <p><strong>Pa&iacute;s:&nbsp;</strong>${objectData.country ? objectData.country : 'No especificado' }</p>
             <p><strong>Fecha de inicio:&nbsp;</strong>${objectData.start_date ? objectData.start_date : 'No especificado'}</p>

--- a/main/templates/subsidy/list.html
+++ b/main/templates/subsidy/list.html
@@ -9,6 +9,17 @@
 {% endblock %}
 
 {% block objectFor %}
+
+<!-- TABLE HEADER -->
+<div id="id-tableHeader" class="container-fluid">
+  <div class="row">
+    <div class="col-lg-5 col-6"><strong>Nombre</strong></div>
+    <div class="col-lg-3 col-3"><strong>Cantidad</strong></div>
+    <div class="col-lg-4 col-3"><strong>Organismo</strong></div>
+  </div>
+  <hr class="my-1">
+</div>
+
 {% for object in objects %}
 
 <div class="container-fluid mw-100  card-list rounded px-2 py-1" tabindex="1">
@@ -16,15 +27,15 @@
    
       
     <div class="row">
-      <div class="col-md-5 col-lg-5 col-sm-6 ">
+      <div class="col-lg-5 col-6 ">
         <strong><h5>{{object.name}}</h5></strong>
       
       </div>
-      <div class="col-md-2 col-lg-3 col-sm-1">
+      <div class="col-lg-3 col-3">
         <span>{{object.amount}} €</span>
 
       </div>  
-      <div class="col-md-3 col-lg-4 col-email col-sm-1">
+      <div class="col-lg-4 col-3">
         <span>{{object.organism}}</span>
 
       </div> 

--- a/main/templates/users/list.html
+++ b/main/templates/users/list.html
@@ -24,18 +24,30 @@
 
 
 {% block objectFor %}
-<form method="GET">
+<form method="GET" class="my-3">
   {% csrf_token %}
   {{form}}
   <input type="submit" value="Filtrar">
 </form>
+
+<!-- TABLE HEADER -->
+<div id="id-tableHeader" class="container-fluid">
+  <div class="row">
+    <div class="col-lg-4 col-6"><strong>Nombre</strong></div>
+    <div class="col-lg-3 col-6"><strong>Ciudad</strong></div>
+    <div class="col-lg-2 col-6"><strong>Tel&eacute;fono</strong></div>
+    <div class="col-lg-3 col-6"><strong>E-mail</strong></div>
+  </div>
+  <hr class="my-1">
+</div>
+
 {% for object in objects %}
 
 {% include 'components/card-list.html' with object_name=object_name  name=object.name surnames=object.surname %}
 <span class="object-id d-none">{{ object.id }}</span>
 
 {% endfor %}
-<div class="pagination">
+<div class="pagination my-4">
   <span class="step-links">
       {% if objects.has_previous %}
           <a href="?page=1">&laquo; Primera</a>
@@ -106,7 +118,7 @@
                 {%endif%}
               </div>
               <div class="row">
-                <h1 class="text-center object-title">${objectData.name+ ' '+ objectData.surname}</h1>
+                <h2 class="text-center object-title" title="${objectData.name+ ' '+ objectData.surname}">${objectData.name+ ' '+ objectData.surname}</h1>
               </div>
               
               <div class="row">

--- a/static/styles/card-list.css
+++ b/static/styles/card-list.css
@@ -39,3 +39,8 @@ a {
   font-weight: bold;
   color: #000;
 }
+
+span {
+  word-wrap: normal;
+  word-break: break-word;
+}

--- a/static/styles/master_sidebar.css
+++ b/static/styles/master_sidebar.css
@@ -86,3 +86,15 @@
     margin-bottom: 1em;
   }
 }
+
+/* TEXT OVERFLOW */
+
+#id-tableHeader {
+  word-wrap: normal;
+  word-break: break-word;
+}
+
+h2, h5 {
+  overflow: hidden;
+  text-overflow: ellipsis;
+}


### PR DESCRIPTION
Also fixed problems with columns and titles' overflow.

Check:
- [x] That all list views have headers (Videssur and Asem)
- [x] That headers are responsive. They may break lines to fit in, that's the expected behaviour.
- [x] Some h2 and h5 have now titles so that long names can fit properly. This is expected to have a rework done in a few days, but it's ok in the meantime. Try and use long names or titles and see if they wrap. If they don't, comment them but it will be fixed in another task.