### PR TITLE
FEAT(#437): ADD SPONSORSHIP FUNCTION

### DIFF
--- a/main/templates/sponsorship/sponsorship_form.html
+++ b/main/templates/sponsorship/sponsorship_form.html
@@ -72,32 +72,6 @@
     </form>
 </div>
 
-<script>
-    document.addEventListener('DOMContentLoaded', function () {
-        const inputs = Array.from(
-            document.querySelectorAll('select[name=godfather], select[name=home]')
-        );
 
-        const selectListener = (e) => {
-            inputs
-            .filter((i) => i !== e.target)
-            .forEach((i) => {
-                i.required = !e.target.value;
-                i.disabled = e.target.value;
-            });
-        };
-
-        // Añadido: Verifica los valores iniciales al cargar la página
-        inputs.forEach((i) => {
-            if (i.value) {
-            selectListener({ target: i });
-            }
-        });
-
-        inputs.forEach((i) => i.addEventListener('input', selectListener));
-        });
-
-
-</script>
 
 {% endblock %}

--- a/main/templates/sponsorship/sponsorship_list.html
+++ b/main/templates/sponsorship/sponsorship_list.html
@@ -1,14 +1,23 @@
+{% extends "layouts/master_sidebar.html" %}
+
 {% load static %}
 
 {% block content %}
 
 {% for o in context.objects %}
-    <p>{{o.slug}}</p>
-    <p>Casa: {{o.home.name}}</p>
+    <h1>Apadrinamiento {{ forloop.counter }}</h1>
+    <p>Niño Apadrinado: {{o.child.name}} {{o.child.surname}}</p>
+    <p>Casas apadrinadoras: </p>
+    {% if o.home.all %}
+        {% for h in o.home.all %}
+            <p> - {{h.name}}</p>
+        {% endfor %}
+    {% else %}
+        <p> - Ninguna</p>
+    {% endif %}
     <p>Padrinos:</p>
     {% for g in o.godfather.all %}
-        <p> - {{g.name}}</p>
+        <p> - {{g.name}} {{g.surname}}</p>
     {% endfor %}
-    <p>Niño: {{o.child.name}}</p>
 {% endfor %}
 {% endblock %}

--- a/main/templates/users/list.html
+++ b/main/templates/users/list.html
@@ -157,8 +157,10 @@
               {%elif object_name == "padrino" or object_name == "donante"%}
               <a id="add-payment" href="../../../payment/create"><i class="bi bi-wallet2"></i>Añadir pago</a>
               {% endif %}
-              {%if object_name == "padrino" or object_name == "niño"%}
-              <a id="add-godfather" href="../../../sponsorship/create"><i class="bi bi-diagram-2"></i>Añadir apadrinamiento</a>
+              {%if object_name == "niño"%}
+              <a id="add-godfather" href="../../../sponsorship/create?child=${ objectData.id }"><i class="bi bi-diagram-2"></i>Añadir apadrinamiento</a>
+              {%elif object_name == "padrino"%}
+              <a id="add-godfather" href="../../../sponsorship/create?godfather=${ objectData.id }"><i class="bi bi-diagram-2"></i>Añadir apadrinamiento</a>
               {% endif %}
               <a id="update-button" href="${ objectData.id }/update"><i class="bi bi-pencil"></i>Editar</a>
               <a id="delete-button" href="${ objectData.id }/delete"><i class="bi bi-x"></i>Eliminar</a>

--- a/sponsorship/models.py
+++ b/sponsorship/models.py
@@ -13,8 +13,8 @@ class Sponsorship(models.Model):
         person_models.GodFather, verbose_name="Padrinos", blank=True)
     child = models.ForeignKey(
         person_models.Child, verbose_name="Niños", on_delete=models.CASCADE)
-    home = models.ForeignKey(
-        home_models.Home, verbose_name="Casa", on_delete=models.SET_NULL, null=True, blank=True)
+    home = models.ManyToManyField(
+        home_models.Home, verbose_name="Casas", blank=True)
 
     # Comentado slug porque da muchos problemas con el ManytoMany
     # slug = models.SlugField(max_length=200, unique=True, editable=False)
@@ -33,11 +33,10 @@ class Sponsorship(models.Model):
                 if self.sponsorship_date > self.termination_date:
                     raise ValidationErr(
                         "La fecha de empadronamiento no puede ser posterior a la fecha de baja")
-
-            if self.sponsorship_date < self.child.birth_date:
-                raise ValidationErr(
-                    "La fecha de empadronamiento no puede ser anterior a la fecha de nacimiento del niño")
-
+            if self.child.birth_date is not None:
+                if self.sponsorship_date < self.child.birth_date:
+                    raise ValidationErr(
+                        "La fecha de empadronamiento no puede ser anterior a la fecha de nacimiento del niño")
         super(Sponsorship, self).save(*args, **kwargs)
 
     class Meta:

--- a/sponsorship/models.py
+++ b/sponsorship/models.py
@@ -32,11 +32,11 @@ class Sponsorship(models.Model):
             if self.termination_date is not None:
                 if self.sponsorship_date > self.termination_date:
                     raise ValidationErr(
-                        "La fecha de empadronamiento no puede ser posterior a la fecha de baja")
+                        "La fecha de apadrinamiento no puede ser posterior a la fecha de baja")
             if self.child.birth_date is not None:
                 if self.sponsorship_date < self.child.birth_date:
                     raise ValidationErr(
-                        "La fecha de empadronamiento no puede ser anterior a la fecha de nacimiento del niño")
+                        "La fecha de apadrinamiento no puede ser anterior a la fecha de nacimiento del niño")
         super(Sponsorship, self).save(*args, **kwargs)
 
     class Meta:

--- a/sponsorship/tests.py
+++ b/sponsorship/tests.py
@@ -50,10 +50,10 @@ class SponsorshipTestCase(TestCase):
         child_test = Child.objects.get(email="test1@test.com")
         home_test = Home.objects.get(name='Casa Paco')
 
-        sponsorship = Sponsorship(sponsorship_date=date.today(), termination_date=date.today(
-        ), child=child_test, home=home_test)
-        sponsorship.save()
+        sponsorship = Sponsorship(id=1,sponsorship_date=date.today(), termination_date=date.today(
+        ), child=child_test)
         sponsorship.godfather.add(god_test)
+        sponsorship.home.add(home_test)
         sponsorship.save()
         num_test = Sponsorship.objects.all().count()
         self.assertEqual(num_test, 1)
@@ -61,8 +61,9 @@ class SponsorshipTestCase(TestCase):
     def test_sponsorship_fail_child_null(self):
         home_test = Home.objects.get(name='Casa Paco')
         with self.assertRaises(Exception):
-            sponsorship = Sponsorship(sponsorship_date=date.today(
-            ), termination_date=date.today(), home=home_test)
+            sponsorship = Sponsorship(id=2, sponsorship_date=date.today(
+            ), termination_date=date.today())
+            sponsorship.home.add(home_test)
             sponsorship.save()
 
     def test_sponsorship_fail_attributes_dateStart(self):
@@ -71,8 +72,9 @@ class SponsorshipTestCase(TestCase):
         home_test = Home.objects.get(name='Casa Paco')
 
         with self.assertRaises(Exception):
-            sponsorship = Sponsorship(sponsorship_date="prueba", termination_date=date.today(
-            ), child=child_test, home=home_test, godfather=god_test)
+            sponsorship = Sponsorship(id=2, sponsorship_date="prueba", termination_date=date.today(
+            ), child=child_test)
+            sponsorship.godfather.add(god_test)
             sponsorship.save()
 
     def test_sponsorship_fail_attributes_dateEnd(self):
@@ -82,8 +84,11 @@ class SponsorshipTestCase(TestCase):
 
         with self.assertRaises(Exception):
             sponsorship = Sponsorship(sponsorship_date=date.today(
-            ), termination_date="prueba", child=child_test, home=home_test, godfather=god_test)
+            ), termination_date="prueba", child=child_test)
+            sponsorship.godfather.add(god_test)
             sponsorship.save()
+
+
 
 class SponsorshipUpdateTestCase(TestCase):
 
@@ -128,7 +133,7 @@ class SponsorshipUpdateTestCase(TestCase):
                              start_date=datetime(2006, 2, 23), termination_date=datetime(2020, 9, 12), educational_level="Test1", expected_mission_time="2",
                              mission_house="Test1", site="Test1", subsite="Test1", father_name="Dn. Test1", father_profession="Test1",
                              mother_name="Sra. Test1", mother_profession="Test1", number_brothers_siblings=3, correspondence="Test1", ong=self.ong)
-        
+
         Child.objects.create(email='test2@test.com', name='Test_1', surname='Test1 Test1', birth_date=datetime(2001, 6, 18),
                              sex="Femenino", city="Test1", address="Test1", telephone=123456789, postal_code=12345, photo="test1.jpg",
                              start_date=datetime(2006, 2, 23), termination_date=datetime(2020, 9, 12), educational_level="Test1", expected_mission_time="2",
@@ -162,10 +167,10 @@ class SponsorshipUpdateTestCase(TestCase):
         child_test = Child.objects.get(email="test1@test.com")
         home_test = Home.objects.get(name='Casa Paco')
 
-        sponsorship = Sponsorship(sponsorship_date=date.today(), termination_date=date.today(
-        ), child=child_test, home=home_test)
-        sponsorship.save()
+        sponsorship = Sponsorship(id=2, sponsorship_date=date.today(), termination_date=date.today(
+        ), child=child_test)
         sponsorship.godfather.add(god_test)
+        sponsorship.home.add(home_test)
         sponsorship.save()
 
     def test_sponsorship_update_correct(self):
@@ -173,17 +178,17 @@ class SponsorshipUpdateTestCase(TestCase):
         god2_test = GodFather.objects.get(email='emailja2@gmail.com')
         child2_test = Child.objects.get(email="test2@test.com")
         home2_test = Home.objects.get(name='Casa Pili')
-        sponsorship= Sponsorship.objects.get(godfather=god_test)
+        sponsorship= Sponsorship.objects.get(id=2)
         sponsorship.sponsorship_date = date(2022, 1, 1)
         sponsorship.termination_date = date.today()
         sponsorship.child = child2_test
-        sponsorship.home = home2_test
         sponsorship.godfather.add(god2_test)
+        sponsorship.home.add(home2_test)
         sponsorship.save()
 
     def test_sponsorship_update_incorrect_dates(self):
         god_test = GodFather.objects.get(email='emailja@gmail.com')
-        sponsorship= Sponsorship.objects.get(godfather=god_test)
+        sponsorship= Sponsorship.objects.get(id=2)
         with self.assertRaises(Exception):
             sponsorship.sponsorship_date = date.today()
             sponsorship.termination_date = date(2022, 1, 1)
@@ -191,14 +196,15 @@ class SponsorshipUpdateTestCase(TestCase):
 
     def test_sponsorship_update_incorrect_sponsorship_date(self):
         god_test = GodFather.objects.get(email='emailja@gmail.com')
-        sponsorship= Sponsorship.objects.get(godfather=god_test)
+        sponsorship= Sponsorship.objects.get(id=2)
         with self.assertRaises(Exception):
             sponsorship.sponsorship_date ="prueba"
             sponsorship.save()
 
     def test_sponsorship_update_incorrect_termination_date(self):
         god_test = GodFather.objects.get(email='emailja@gmail.com')
-        sponsorship= Sponsorship.objects.get(godfather=god_test)
+        sponsorship= Sponsorship.objects.get(id=2)
         with self.assertRaises(Exception):
             sponsorship.termination_date ="prueba"
             sponsorship.save()
+

--- a/sponsorship/views.py
+++ b/sponsorship/views.py
@@ -1,6 +1,8 @@
 from django.shortcuts import render, redirect, get_object_or_404
 from django.contrib.auth.decorators import login_required
 from django.contrib import messages
+
+from person.models import Child, GodFather
 from .models import Sponsorship
 from .forms import CreateSponsorshipForm
 from xml.dom import ValidationErr
@@ -11,6 +13,20 @@ from main.views import  videssur_required
 @videssur_required
  
 def sponsorship_create(request):
+    #check if "child" is in the request:
+    if 'child' in request.GET:
+        child = Child.objects.get(id=request.GET.get('child'))
+        active_sponsorship_exist = Sponsorship.objects.filter(child=child, termination_date=None).exists()
+        if active_sponsorship_exist:
+            sponsorship_id = Sponsorship.objects.filter(child=child, termination_date=None).get().id
+            return sponsorship_edit(request, sponsorship_id)
+    else:
+        child = None
+    if 'godfather' in request.GET:
+        godfather = GodFather.objects.get(id=request.GET.get("godfather"))
+    else:
+        godfather = None
+
     if request.method == 'POST':
         form = CreateSponsorshipForm(request.POST)
         if form.is_valid():
@@ -21,7 +37,8 @@ def sponsorship_create(request):
         else:
             messages.error(request, 'El formulario presenta errores')
     else:
-        form = CreateSponsorshipForm()
+        initial_data = {'child': child, 'godfather': godfather}
+        form = CreateSponsorshipForm(initial=initial_data)
 
     return render(request, 'sponsorship/sponsorship_form.html', {'form': form})
 


### PR DESCRIPTION
Now you can add and update sponsorships of children. To test this PR, you must:
- [x] Create two childs, two godfathers and one home
- [x] Add a new sponsorship to one child from child list with no termination date. Notice that the child you clicked to add a new sponsorship is initialize in the form.
- [x] Try to add a new sponsorship to the same child and notice that now you are updating last sponsorship, not creating a new one.
- [x] Add termination date to that sponsorship, try to add a new one for the same child and notice that you are now creating a new one, and not updating the same one. You can check that by seeing that the button text display "Actualizar apadrinamiento" instead of "Añadir apadrinamiento"
- [x] From godfather list, try to add another sponsorship with the same child and test that it fails.
- [x] Try to add or update a sponsorship with no godfathers and no homes, test that it fails.
- [x] Run tests and check that all tests pass with no failure.

Sponsorship list style is not implemented yet. I added the navbar so it can be functional at least.
