### PR TITLE
FIX(#728): FIX DELETE STOCK LINK

### DIFF
--- a/home/forms.py
+++ b/home/forms.py
@@ -9,7 +9,7 @@ class CreateHomeForm(forms.ModelForm):
         widgets = {
             'start_date': forms.DateInput(attrs={'type': 'date'}, format='%Y-%m-%d'),
             'termination_date': forms.DateInput(attrs={'type': 'date'}, format='%Y-%m-%d'),
-            'amount': forms.NumberInput(attrs={'step': "0.01"}),
+            'amount': forms.NumberInput(attrs={'step': "0.1", 'min': '1'}),
         }
         error_messages = {
             'bank_account_number': {

--- a/main/templates/stock/list.html
+++ b/main/templates/stock/list.html
@@ -115,10 +115,19 @@
             let confirmMessage = confirm("¿Estás seguro de que quieres eliminar este producto?");
             if (!confirmMessage) {
                 e.preventDefault();
+            }else{
+                sessionStorage.setItem("query", window.location.search);
             }
         });
     });
+</script>
 
-
+<script>
+    window.addEventListener('load', (event) => {
+        if(sessionStorage.getItem("query")) {
+            window.location.href = window.location.href + sessionStorage.getItem("query")
+        }
+        sessionStorage.removeItem("query")
+    });
 </script>
 {% endblock %}

--- a/payment/forms.py
+++ b/payment/forms.py
@@ -8,7 +8,7 @@ class CreatePaymentForm(forms.ModelForm):
         exclude = ['id', 'ong']
         widgets = {
             'payday': forms.DateInput(attrs={'type': 'date'}, format='%Y-%m-%d'),
-            'amount': forms.NumberInput(attrs={'class': 'form-control', 'step': "0.01", "min": 0, "placeholder": "Escriba una cantidad"}),
+            'amount': forms.NumberInput(attrs={'class': 'form-control', 'step': "0.1", "min": 0, "placeholder": "Escriba una cantidad"}),
             'concept': forms.TextInput(attrs={"placeholder": "Introduzca un concepto"}),
 
         }

--- a/person/forms.py
+++ b/person/forms.py
@@ -150,7 +150,7 @@ class CreateNewGodFather(forms.ModelForm):
             'birth_date': forms.DateInput(attrs={'type': 'date'}, format='%Y-%m-%d'),
             'start_date': forms.DateInput(attrs={'type': 'date'}, format='%Y-%m-%d'),
             'termination_date': forms.DateInput(attrs={'type': 'date'}, format='%Y-%m-%d'),
-            'amount': forms.NumberInput(attrs={'step': "0.01"}),
+            'amount': forms.NumberInput(attrs={'step': "0.01", 'min': '1'}),
             'sex': forms.Select(attrs={'step': "0.01"}),
             'payment_method': forms.Select(choices=PAYMENT_METHOD),
         }
@@ -202,6 +202,7 @@ class CreateNewASEMUser(forms.ModelForm):
         exclude = ['id', 'ong']  # ong should be ASEM
         widgets = {
             'birth_date': forms.DateInput(attrs={'type': 'date'}, format='%Y-%m-%d'),
+            'family_unit_size': forms.NumberInput(attrs={'min': 0}),
         }
 
     def __init__(self, *args, **kwargs):
@@ -407,7 +408,7 @@ class CreateNewVolunteer(forms.ModelForm):
             'birth_date': forms.DateInput(attrs={'class': 'form-control', 'type': 'date'}, format='%Y-%m-%d'),
             'contract_start_date': forms.DateInput(attrs={'class': 'form-control', 'type': 'date'}, format='%Y-%m-%d'),
             'contract_end_date': forms.DateInput(attrs={'class': 'form-control', 'type': 'date'}, format='%Y-%m-%d'),
-            'dedication_time': forms.NumberInput(attrs={'step': "0.01", 'min': 0}),
+            'dedication_time': forms.NumberInput(attrs={'step': "0.1", 'min': 0}),
         }
 
     def __init__(self, *args, **kwargs):

--- a/project/forms.py
+++ b/project/forms.py
@@ -64,6 +64,8 @@ class CreateNewProject(forms.ModelForm):
             'start_date': forms.DateInput(attrs={'type': 'date'}, format='%Y-%m-%d'),
             'end_date': forms.DateInput(attrs={'type': 'date'}, format='%Y-%m-%d'),
             'announcement_date': forms.DateInput(attrs={'type': 'date'}, format='%Y-%m-%d'),
+            'amount': forms.NumberInput(attrs={'step': '0.1', 'min': 1}),
+            'number_of_beneficiaries': forms.NumberInput(attrs={'min': 0}),
         }
 
     def __init__(self, *args, **kwargs):

--- a/stock/forms.py
+++ b/stock/forms.py
@@ -10,7 +10,7 @@ class CreateNewStock(forms.ModelForm):
             'name': forms.TextInput(attrs={'placeholder': 'Nombre del producto', 'maxlength': '200', 'required': 'true'}),
             'model': forms.TextInput(attrs={'placeholder': 'Modelo del producto', 'maxlength': '200'}),
             'quantity': forms.NumberInput(attrs={'placeholder': 'Cantidad', 'step': '1', 'required': 'true', 'min': '0'}),
-            'amount': forms.NumberInput(attrs={'placeholder': 'Precio', 'step': "0.1", 'min': '0'}),
+            'amount': forms.NumberInput(attrs={'placeholder': 'Precio', 'step': "0.01", 'min': '0'}),
             'notes': forms.TextInput(attrs={'placeholder': 'Observaciones'})
             # 'file': forms.FileInput(attrs={'class': 'form-control-file'}),
 

--- a/stock/forms.py
+++ b/stock/forms.py
@@ -9,8 +9,8 @@ class CreateNewStock(forms.ModelForm):
         widgets = {
             'name': forms.TextInput(attrs={'placeholder': 'Nombre del producto', 'maxlength': '200', 'required': 'true'}),
             'model': forms.TextInput(attrs={'placeholder': 'Modelo del producto', 'maxlength': '200'}),
-            'quantity': forms.NumberInput(attrs={'placeholder': 'Cantidad', 'step': '1', 'required': 'true'}),
-            'amount': forms.NumberInput(attrs={'placeholder': 'Precio', 'step': "0.01"}),
+            'quantity': forms.NumberInput(attrs={'placeholder': 'Cantidad', 'step': '1', 'required': 'true', 'min': '0'}),
+            'amount': forms.NumberInput(attrs={'placeholder': 'Precio', 'step': "0.1", 'min': '0'}),
             'notes': forms.TextInput(attrs={'placeholder': 'Observaciones'})
             # 'file': forms.FileInput(attrs={'class': 'form-control-file'}),
 

--- a/subsidy/forms.py
+++ b/subsidy/forms.py
@@ -13,7 +13,7 @@ class CreateNewSubsidy(forms.ModelForm):
             'provisional_resolution': forms.DateInput(attrs={'type': 'date'}, format='%Y-%m-%d'),
             'ong': forms.Select(attrs={'class': 'form-select w-100 mb-3', 'disabled': True}),
             'final_resolution': forms.DateInput(attrs={'type': 'date'}, format='%Y-%m-%d'),
-            'amount': forms.NumberInput(attrs={'step': "0.1", 'min': '0'}),
+            'amount': forms.NumberInput(attrs={'step': "0.01", 'min': '0'}),
         }
 
     def __init__(self, *args, **kwargs):

--- a/subsidy/forms.py
+++ b/subsidy/forms.py
@@ -13,7 +13,7 @@ class CreateNewSubsidy(forms.ModelForm):
             'provisional_resolution': forms.DateInput(attrs={'type': 'date'}, format='%Y-%m-%d'),
             'ong': forms.Select(attrs={'class': 'form-select w-100 mb-3', 'disabled': True}),
             'final_resolution': forms.DateInput(attrs={'type': 'date'}, format='%Y-%m-%d'),
-            'amount': forms.NumberInput(attrs={'step': "0.01"}),
+            'amount': forms.NumberInput(attrs={'step': "0.1", 'min': '0'}),
         }
 
     def __init__(self, *args, **kwargs):


### PR DESCRIPTION
Added js to delete buttons that, first, save the query in session storage, and then, when the list page loads it adds the query to the url.

To review, try to delete a stock item in either a page different than the first or with a filter.