### PR TITLE
FIX(#737): ADD ERROR MESSAGES TO FORMS

### DIFF
--- a/main/templates/payment/payment_form.html
+++ b/main/templates/payment/payment_form.html
@@ -6,8 +6,20 @@
 {% block leftSide %}
 {% include 'components/title2.html' with title=title %}
 
+{% if messages %}
+<div class="row">
+    {% for message in messages %}
+    <div class="alert alert-danger alert-dismissible fade show" role="alert">
+        {{ message }}
+        <button type="button" class="btn-close" data-bs-dismiss="alert" aria-label="Close"></button>
+    </div>
+    {% endfor %}
+</div>
+{% endif %}
+
 <form method="post" action="">
   {% csrf_token %}
+  {{ form.non_field_errors }}
     <div class="row my-4 mx-5 justify-content-center">
       
       <div class="my-2 mx-5 d-flex flex-column text-start">

--- a/main/templates/service/service_form.html
+++ b/main/templates/service/service_form.html
@@ -6,6 +6,17 @@
 {% block leftSide %}
 {% include 'components/title2.html' with title=title %}
 
+{% if messages %}
+<div class="row">
+    {% for message in messages %}
+    <div class="alert alert-danger alert-dismissible fade show" role="alert">
+        {{ message }}
+        <button type="button" class="btn-close" data-bs-dismiss="alert" aria-label="Close"></button>
+    </div>
+    {% endfor %}
+</div>
+{% endif %}
+
 <form method="post" action="">
   {% csrf_token %}
     <div class="row my-4 mx-5 justify-content-center">
@@ -23,7 +34,9 @@
             {% include 'components/inputs.html' with id=field.id_for_label label_text=field.label_tag input=field %}
           {% endif %}
         </div>
-
+        <div class="row text-danger">
+          {{ field.errors }}
+        </div>
       {% endfor %}
 
       </div> 
@@ -32,26 +45,6 @@
         <p class="text-danger">* Campos obligatorios</p>
       </div>
 
-      {% comment %} 
-      <div class="my-2 mx-5 d-flex flex-column text-start">
-        <div class="mt-3">
-          {% include "components/inputs.html" with id=form.concept.id_for_label label_text=form.concept.label_tag input=form.concept %} 
-          {{ form.concept.errors }}
-        </div>
-        <div class="mt-3">
-          {% include "components/inputs.html" with id=form.amount.id_for_label label_text=form.amount.label_tag input=form.amount %} 
-          {{ form.amount.errors }}
-        </div>
-        <div class="mt-3">
-          {% include "components/inputs.html" with id=form.date.id_for_label label_text=form.date.label_tag input=form.date  %}
-          {{ form.date.errors }}
-        </div>
-        <div class="mt-3">
-          {% include "components/inputs.html" with id=form.paid.id_for_label label_text=form.paid.label_tag input=form.paid  %}
-          {{ form.paid.errors }}
-        </div>
-      </div> 
-      {% endcomment %}
       <div class="form-section mt-5 mx-5 text-center">
         {% if form.instance.id %}
           {% with button_text="Actualizar" %}

--- a/main/templates/stock/register.html
+++ b/main/templates/stock/register.html
@@ -14,28 +14,45 @@
         {% include 'components/title.html' with title="Añadir producto" %}
     {% endif %}
 
+    {% if messages %}
+        <div class="row">
+            {% for message in messages %}
+            <div class="alert alert-danger alert-dismissible fade show" role="alert">
+                {{ message }}
+                <button type="button" class="btn-close" data-bs-dismiss="alert" aria-label="Close"></button>
+            </div>
+            {% endfor %}
+        </div>
+    {% endif %}
+
     <form method="post" enctype="multipart/form-data">
     {% csrf_token %}
+    {{ form.non_field_errors }}
         <div class="row justify-content-between mx-4 mt-3">
             <div class="col-12 col-sm-4  mx-2 ">
                 <div class="row pt-1">
                     {% with label_text="Nombre"|safe|add:'<span class="text-danger"> *</span>' %}
                         {% include 'components/inputs.html' with id=form.name.id_for_label label_text=label_text input=form.name %}
+                        {{ form.name.errors }}
                     {% endwith %}
                 </div>
                 <div class="row pt-4">                  
                     {% include "components/inputs.html" with id=form.model.id_for_label label_text="Modelo" input=form.model %}
+                    {{ form.model.errors }}
                 </div>
                 <div class="row pt-4">        
                     {% with label_text="Unidades"|safe|add:'<span class="text-danger"> *</span>' %}
                         {% include 'components/inputs.html' with id=form.quantity.id_for_label label_text=label_text input=form.quantity %}
+                        {{ form.quantity.errors }}
                     {% endwith %}          
                 </div>
                 <div class="row pt-4">                  
                     {% include "components/inputs.html" with id=form.amount.id_for_label label_text="Precio (€)" input=form.amount %}
+                    {{ form.amount.errors }}
                 </div>
                 <div class="row pt-4 mb-4">                  
                     {% include "components/inputs.html" with id=form.notes.id_for_label label_text="Observaciones" input=form.notes %}
+                    {{ form.notes.errors }}
                 </div>
                 <div class="col-12">
                     <p class="text-danger">* Campos obligatorios</p>
@@ -50,6 +67,7 @@
                     <div class=" row d-flex justify-content-center  ">
                         <div class="col-8">
                             {% include "components/inputs.html" with id=form.photo.id_for_label input=form.photo  %}
+                            {{ form.photo.errors }}
                         </div>
                     </div>
                 </div>

--- a/main/templates/subsidy/create.html
+++ b/main/templates/subsidy/create.html
@@ -3,12 +3,16 @@
 
 {% block content %}
 <div id="section-subsidy">
-  {% for message in messages %}
-  <div class="alert alert-danger alert-dismissible fade show" role="alert">
-      {{ message }}
-      <button type="button" class="btn-close" data-bs-dismiss="alert" aria-label="Close"></button>
-  </div>
-  {% endfor %}
+  {% if messages %}
+    <div class="row">
+        {% for message in messages %}
+        <div class="alert alert-danger alert-dismissible fade show" role="alert">
+            {{ message }}
+            <button type="button" class="btn-close" data-bs-dismiss="alert" aria-label="Close"></button>
+        </div>
+        {% endfor %}
+    </div>
+  {% endif %}
   {% if form.instance.id %}
       {% include 'components/title.html' with title="Editar subvención" %}
   {% else %}
@@ -16,6 +20,7 @@
   {% endif %}
   <form method="post" enctype='multipart/form-data' action="">
     {% csrf_token %}
+    {{ form.non_field_errors }}
       <div class="row mx-5">
         <div class="col-sm-12 col-lg-6 my-3">
         {% include "components/inputs.html" with id=form.name.id_for_label label_text=field.label_tag|safe|add:'Nombre<span class="text-danger"> *</span>' input=form.name %} 


### PR DESCRIPTION
In this PR I added a section in which error messages of forms should appear. 

To review it, try to make as many illegal operations on forms as you could, and if for some reason an error is thrown, you should be able to see it.